### PR TITLE
解决SamuraiDocument和SamuraiRenderObject被循环引用的问题

### DIFF
--- a/samurai-framework/samurai-ui/modules/view-core/Samurai_RenderObject.h
+++ b/samurai-framework/samurai-ui/modules/view-core/Samurai_RenderObject.h
@@ -76,7 +76,7 @@
 
 @interface NSObject(Renderer)
 
-@prop_strong( SamuraiRenderObject *, renderer );
+@prop_unsafe( SamuraiRenderObject *, renderer );
 
 + (id)createInstanceWithRenderer:(SamuraiRenderObject *)renderer;	// override point
 + (id)createInstanceWithRenderer:(SamuraiRenderObject *)renderer identifier:(NSString *)identifier;	// override point

--- a/samurai-framework/samurai-ui/modules/view-core/Samurai_RenderObject.m
+++ b/samurai-framework/samurai-ui/modules/view-core/Samurai_RenderObject.m
@@ -53,7 +53,7 @@
 
 @implementation NSObject(Renderer)
 
-@def_prop_dynamic_strong( SamuraiRenderObject *, renderer, setRenderer );
+@def_prop_dynamic_weak( SamuraiRenderObject *, renderer, setRenderer );
 
 + (id)createInstanceWithRenderer:(SamuraiRenderObject *)renderer
 {

--- a/samurai-framework/samurai-ui/modules/view-core/Samurai_ViewWorkflow.h
+++ b/samurai-framework/samurai-ui/modules/view-core/Samurai_ViewWorkflow.h
@@ -50,7 +50,7 @@
 
 @interface SamuraiViewWorkflow : NSObject
 
-@prop_strong( NSObject *,		context );
+@prop_unsafe( NSObject *,		context );
 @prop_strong( NSMutableArray *,	worklets );
 
 + (instancetype)workflow;

--- a/samurai-framework/samurai-ui/modules/view-core/Samurai_ViewWorkflow.m
+++ b/samurai-framework/samurai-ui/modules/view-core/Samurai_ViewWorkflow.m
@@ -60,7 +60,7 @@
 
 @implementation SamuraiViewWorkflow
 
-@def_prop_strong( NSObject *,		context );
+@def_prop_unsafe( NSObject *,		context );
 @def_prop_strong( NSMutableArray *,	worklets );
 
 + (instancetype)workflow


### PR DESCRIPTION
原来的代码存在循环引用，导致切换主题，进入页面退出之后所有创建的Document和RenderObject都无法被释放。复现方式：在`SamuraiDocument`或`SamuraiRenderObject`的`dealloc`方法里打断点，切换主题或者进入任何页面退出后都无法断到`dealloc`。

我查看了一下代码里面关于SamuraiDocument和SamuraiRenderObject的引用关系和生命周期，把一些导致循环引用的地方改成弱引用了：

 [Samurai_RenderObject在创建view的时候](https://github.com/hackers-painters/samurai-native/blob/202b54236d4ee395d8e396bf4071ac2720897170/samurai-framework/samurai-ui/modules/view-core/Samurai_RenderObject.m#L436),   [把view的renderObject设成了自己](https://github.com/hackers-painters/samurai-native/blob/master/samurai-framework/samurai-ui/modules/view-component/Samurai_UIView.m#L62) 导致View和RenderObject互相持有了。

[Samurai_HtmlDocument在parse的时候创建的SamuraiHtmlDocumentWorkflow_Parser](https://github.com/hackers-painters/samurai-native/blob/master/samurai-framework/samurai-ui/extension-html/document/Samurai_HtmlDocument.m#L102),  [把parser的context设成了自己](https://github.com/hackers-painters/samurai-native/blob/master/samurai-framework/samurai-ui/modules/view-core/Samurai_ViewWorkflow.m#L74)  导致Document和Parser互相持有了。
